### PR TITLE
Bv branch

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func createFlags() {
 	//mtls
 	flag.StringVar(&config.Mcfg.Crtpath, "crt-path", "./cert.pem", "Heplify agent mTLS certificate")
 	flag.StringVar(&config.Mcfg.Keypath, "key-path", "./key.pem", "Heplify agent mTLS key")
-	flag.StringVar(&config.Mcfg.Chainpath, "chain-path", "./chain.pem", "Heplify server mTLS cert chain. Only specified if server using self-signed certificates")
+	flag.StringVar(&config.Mcfg.Chainpath, "chain-path", "", "Heplify server mTLS cert chain. Only specified if server using self-signed certificates")
 
 	//short
 	flag.StringVar(&config.Cfg.Filter, "fi", "", "Filter interesting packets by any string")

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func createFlags() {
 	//mtls
 	flag.StringVar(&config.Mcfg.Crtpath, "crt-path", "./cert.pem", "Heplify agent mTLS certificate")
 	flag.StringVar(&config.Mcfg.Keypath, "key-path", "./key.pem", "Heplify agent mTLS key")
-	flag.StringVar(&config.Mcfg.Chainpath, "chain-path", "./chain.pem", "Heplify server mTLS cert chain")
+	flag.StringVar(&config.Mcfg.Chainpath, "chain-path", "./chain.pem", "Heplify server mTLS cert chain. Only specified if server using self-signed certificates")
 
 	//short
 	flag.StringVar(&config.Cfg.Filter, "fi", "", "Filter interesting packets by any string")

--- a/publish/hep.go
+++ b/publish/hep.go
@@ -128,10 +128,22 @@ func (h *HEPOutputer) ConnectServer(n int) (err error) {
 				panic(err)
 			}
 		}
+		var caCertPool *x509.CertPool
+		//serverChain is normally empty, unless a custom root-int-chain ha sbeen specified via argument
 		if serverChain == "" {
-			serverChain, err = loadFile(config.Mcfg.Chainpath)
-			if err != nil {
-				panic(err)
+			if config.Mcfg.Chainpath != "" {
+				serverChain, err = loadFile(config.Mcfg.Chainpath)
+				if err != nil {
+					panic(err)
+				}
+
+				//Load trusted RootCA from file
+				caCertPool = x509.NewCertPool()
+				caCertPool.AppendCertsFromPEM([]byte(serverChain))
+
+			} else {
+				//renewRootCAs() reads trusted RootCAs from OS
+				caCertPool = renewRootCAs()
 			}
 		}
 		if agentKey == "" {
@@ -144,8 +156,7 @@ func (h *HEPOutputer) ConnectServer(n int) (err error) {
 		if err != nil {
 			panic(err)
 		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM([]byte(serverChain))
+
 		if h.client[n].conn, err = tls.Dial("tcp", h.addr[n], &tls.Config{
 			InsecureSkipVerify: false,
 			RootCAs:            caCertPool,

--- a/publish/mtls.go
+++ b/publish/mtls.go
@@ -1,6 +1,9 @@
 package publish
 
-import "os"
+import (
+	"crypto/x509"
+	"os"
+)
 
 /*
 Certificate, key and chain can be embedded before building the binary by
@@ -31,3 +34,13 @@ xkKI+Y6MRPBb2qXcYfeS/0FI
 var agentCert string
 var serverChain string
 var agentKey string
+
+// Read trusted RootCAs from operating system store
+func renewRootCAs() *x509.CertPool {
+	rootcas, err := x509.SystemCertPool()
+	if err != nil || rootcas == nil {
+		panic("Unable lto load/renew RootCAs from Operating System")
+	}
+
+	return rootcas
+}


### PR DESCRIPTION
Previously a new empty certificate pool would be created, and the server's certificate chain would need to be provided. Now:

- if `-chain-path` is specified, the same behaviour will take place as before. This is useful if using a private/self-signed authority
- if **no** `-chain-path` is specified, then the binary will read from the host system's trusted certificate store.

This behaviour is only trigered if the network type (`-nt`) is "mtls"